### PR TITLE
Port to tf.keras

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Keras>=2.2.0
 pronouncing>=0.2.0
 scikit-learn>=0.20.0
 tensorflow>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,14 @@ with open('README.md') as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    'Keras>=2.2.0',
+    'tensorflow>=2.0.0',
     'pronouncing>=0.2.0',
     'scikit-learn>=0.20.0'
 ]
 
 setup(
     name='pincelate',
-    version='0.0.1',
+    version='0.0.2',
     description="Easy to use ML model for spelling and sounding out words",
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Hopefully, at least partially, solves https://github.com/aparrish/pincelate/issues/3

Changes:
- Changed keras -> tf.keras
- Fixed load_weights not accepting file handles anymore.

Notes:
Warning shown is supposed to be fixed: https://github.com/tensorflow/tensorflow/issues/38561#issuecomment-629937796, but still shows up, so not sure about that.

test_phonemefeatures and test_phonemestate both fail, however, they both fail on tensorflow==1.15.2 and keras==2.2.5 already, so I ignored them.